### PR TITLE
remove all routes when logging out

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -238,8 +238,8 @@ class ProfileState extends State<Profile> with AutomaticKeepAliveClientMixin {
                     onTap: () {
                       var db = DatabaseHelper();
                       db.deleteUsers().then((_) {
-                        Navigator.of(context).pushNamedAndRemoveUntil(
-                            "/login", ModalRoute.withName("/home"));
+                        Navigator.of(context)
+                            .pushNamedAndRemoveUntil("/login", (_) => false);
                       });
                     },
                     child: Padding(


### PR DESCRIPTION
Before this commit, the home page remained on the navigator stack after logging out. This meant that the home page could be returned to after logging out which caused errors. 

After this commit, all routes except the login route are removed.